### PR TITLE
Fix error handling in ApplyingInstructions

### DIFF
--- a/src/components/applying-instructions.tsx
+++ b/src/components/applying-instructions.tsx
@@ -78,9 +78,9 @@ export function ApplyingInstructions({
 			// Use the child_process module through window.electron
 			const result = await window.electron.executeCommand(command)
 
-			if (result.error) {
+			if (!result.success) {
 				setAutoApplyStatus("error")
-				setErrorMessage(result.error)
+				setErrorMessage(result.output) // Use output for error message
 			} else {
 				setAutoApplyStatus("success")
 			}


### PR DESCRIPTION
Updates error handling to match the actual response type structure (`{ success: boolean; output: string }`), fixing TypeScript errors in applying-instructions.tsx.

## Changes
- Use `result.success` for error checking
- Use `result.output` for error messages
- Remove references to non-existent `error` property